### PR TITLE
Added hooks to enrich the raw swagger data

### DIFF
--- a/src/Nancy.Swagger.Annotations/Enrichers/DefaultSwaggerDataEnricherCatalog.cs
+++ b/src/Nancy.Swagger.Annotations/Enrichers/DefaultSwaggerDataEnricherCatalog.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Nancy.Swagger.Annotations.Enrichers
+{
+    public class DefaultSwaggerDataEnricherCatalog : List<ISwaggerDataEnricher>, ISwaggerDataEnricherCatalog
+    {
+        public DefaultSwaggerDataEnricherCatalog()
+        {
+        }
+
+        public DefaultSwaggerDataEnricherCatalog(IEnumerable<ISwaggerDataEnricher> enrichers)
+            : base(enrichers)
+        {
+        }
+    }
+}

--- a/src/Nancy.Swagger.Annotations/Enrichers/ISwaggerDataEnricher.cs
+++ b/src/Nancy.Swagger.Annotations/Enrichers/ISwaggerDataEnricher.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+
+namespace Nancy.Swagger.Annotations.Enrichers
+{
+    public interface ISwaggerDataEnricher
+    {
+        void Enrich(SwaggerRouteData data);
+
+        void Enrich(SwaggerModelData data);
+
+        void Enrich(SwaggerModelPropertyData data, PropertyInfo propertyInfo);
+
+        void Enrich(SwaggerParameterData parameterData, ParameterInfo parameterInfo);
+    }
+}

--- a/src/Nancy.Swagger.Annotations/Enrichers/ISwaggerDataEnricherCatalog.cs
+++ b/src/Nancy.Swagger.Annotations/Enrichers/ISwaggerDataEnricherCatalog.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace Nancy.Swagger.Annotations.Enrichers
+{
+    public interface ISwaggerDataEnricherCatalog : IEnumerable<ISwaggerDataEnricher>
+    {
+    }
+}

--- a/src/Nancy.Swagger.Annotations/Enrichers/JsonNetEnricher.cs
+++ b/src/Nancy.Swagger.Annotations/Enrichers/JsonNetEnricher.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Nancy.Swagger.Annotations.Enrichers
+{
+    public class JsonNetEnricher : ISwaggerDataEnricher
+    {
+        public void Enrich(SwaggerModelData data)
+        {
+            foreach (var attr in GetAttributes(data.ModelType, "Newtonsoft.Json.JsonObjectAttribute"))
+            {
+                var type = attr.GetType();
+                data.Description = GetPropertyValue<string>(type, attr, "Description") ?? data.Description;
+            }
+        }
+
+        public void Enrich(SwaggerRouteData data)
+        {
+        }
+
+        public void Enrich(SwaggerModelPropertyData data, PropertyInfo propertyInfo)
+        {
+            foreach (var attr in GetAttributes(propertyInfo, "Newtonsoft.Json.JsonPropertyAttribute"))
+            {
+                var type = attr.GetType();
+
+                data.Name = GetPropertyValue<string>(type, attr, "PropertyName") ?? data.Name;
+
+                var required = GetPropertyValue<object>(type, attr, "Required");
+                if (required != null && required.ToString() == "Always")
+                {
+                    data.Required = true;
+                }
+            }
+        }
+
+        public void Enrich(SwaggerParameterData parameterData, ParameterInfo parameterInfo)
+        {
+        }
+
+        private static T GetPropertyValue<T>(Type type, object obj, string propertyName)
+        {
+            var value = type.GetProperty(propertyName).GetValue(obj, null);
+
+            return value == null ? default(T) : (T)value;
+        }
+
+        private IList<Attribute> GetAttributes(MemberInfo memberInfo, string attrFullTypeName)
+        {
+            return memberInfo.GetCustomAttributes(true)
+                             .Cast<Attribute>()
+                             .Where(attr => attr.GetType().FullName == attrFullTypeName)
+                             .ToList();
+        }
+    }
+}

--- a/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
+++ b/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
@@ -58,10 +58,15 @@
     <Compile Include="Attributes\SwaggerRouteAttribute.cs" />
     <Compile Include="Attributes\SwaggerRouteParamAttribute.cs" />
     <Compile Include="Attributes\SwaggerResponse.cs" />
+    <Compile Include="Enrichers\JsonNetEnricher.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="Enrichers\DefaultSwaggerDataEnricherCatalog.cs" />
+    <Compile Include="Enrichers\ISwaggerDataEnricher.cs" />
+    <Compile Include="Enrichers\ISwaggerDataEnricherCatalog.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RouteId.cs" />
     <Compile Include="SwaggerAnnotationsConverter.cs" />
+    <Compile Include="SwaggerAnnotationsRegistrations.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nancy.Swagger\Nancy.Swagger.csproj">

--- a/src/Nancy.Swagger.Annotations/SwaggerAnnotationsRegistrations.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerAnnotationsRegistrations.cs
@@ -1,0 +1,14 @@
+﻿using Nancy.Bootstrapper;
+using Nancy.Swagger.Annotations.Enrichers;
+
+namespace Nancy.Swagger.Annotations
+{
+    public class SwaggerAnnotationsRegistrations : Registrations
+    {
+        public SwaggerAnnotationsRegistrations()
+        {
+            RegisterWithDefault<ISwaggerDataEnricherCatalog>(typeof(DefaultSwaggerDataEnricherCatalog));
+            RegisterAll<ISwaggerDataEnricher>();
+        }
+    }
+}

--- a/test/Nancy.Swagger.Annotations.Tests/Nancy.Swagger.Annotations.Tests.csproj
+++ b/test/Nancy.Swagger.Annotations.Tests/Nancy.Swagger.Annotations.Tests.csproj
@@ -43,6 +43,9 @@
     <Reference Include="Nancy.Testing">
       <HintPath>..\..\packages\Nancy.Testing.0.23.0\lib\net40\Nancy.Testing.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -63,9 +66,11 @@
     </Compile>
     <Compile Include="SwaggerAnnotationsConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestModel.cs" />
-    <Compile Include="TestModel.InOtherNamespace.cs" />
-    <Compile Include="TestRoutesModule.cs" />
+    <Compile Include="Testdata\JsonNetEnricher\JsonNetEnricherRoutesModule.cs" />
+    <Compile Include="Testdata\JsonNetEnricher\JsonNetEnricherModel.cs" />
+    <Compile Include="Testdata\TestModel.cs" />
+    <Compile Include="Testdata\TestModel.InOtherNamespace.cs" />
+    <Compile Include="Testdata\TestRoutesModule.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_ApiDocsRootpath_ReturnsResourceListing.approved.json
+++ b/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_ApiDocsRootpath_ReturnsResourceListing.approved.json
@@ -5,6 +5,9 @@
             "path": "/api-docs"
         },
         {
+            "path": "/json-net-enricher-routes"
+        },
+        {
             "path": "/testroutes"
         }
     ]

--- a/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_JsonNetEnricherModulePath_ReturnsApiDeclaration.approved.json
+++ b/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_JsonNetEnricherModulePath_ReturnsApiDeclaration.approved.json
@@ -1,0 +1,43 @@
+﻿{
+    "swaggerVersion": "1.2",
+    "basePath": "/",
+    "apis": [
+        {
+            "path": "/json-net-enricher-routes/models",
+            "operations": [
+                {
+                    "method": "GET",
+                    "nickname": "getJsonNetEnricherRoutesModels",
+                    "parameters": [],
+                    "type": "array",
+                    "items": {
+                        "$ref": "JsonNetEnricherModel"
+                    }
+                }
+            ]
+        }
+    ],
+    "models": {
+        "JsonNetEnricherModel": {
+            "id": "JsonNetEnricherModel",
+            "description": "Description of a model",
+            "required": [
+                "RequiredAlways"
+            ],
+            "properties": {
+                "named": {
+                    "type": "string"
+                },
+                "RequiredAllowNull": {
+                    "type": "string"
+                },
+                "RequiredAlways": {
+                    "type": "string"
+                },
+                "RequiredDefault": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.cs
@@ -1,5 +1,7 @@
 ﻿using ApprovalTests;
 using ApprovalTests.Reporters;
+using Nancy.Swagger.Annotations.Tests.Testdata;
+using Nancy.Swagger.Annotations.Tests.Testdata.JsonNetEnricher;
 using Nancy.Swagger.Modules;
 using Nancy.Swagger.Services;
 using Nancy.Testing;
@@ -21,6 +23,7 @@ namespace Nancy.Swagger.Annotations.Tests
 
                 with.Module<SwaggerModule>();
                 with.Module<TestRoutesModule>();
+                with.Module<JsonNetEnricherRoutesModule>();
             });
 
             _browser = new Browser(bootstrapper);
@@ -42,6 +45,12 @@ namespace Nancy.Swagger.Annotations.Tests
         public void Get_TestModulePath_ReturnsApiDeclaration()
         {
             ApproveJsonResponse(_browser.Get("/api-docs/testroutes"));
+        }
+
+        [Fact]
+        public void Get_JsonNetEnricherModulePath_ReturnsApiDeclaration()
+        {
+            ApproveJsonResponse(_browser.Get("/api-docs/json-net-enricher-routes"));
         }
 
         private static void ApproveJsonResponse(BrowserResponse response)

--- a/test/Nancy.Swagger.Annotations.Tests/Testdata/JsonNetEnricher/JsonNetEnricherModel.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/Testdata/JsonNetEnricher/JsonNetEnricherModel.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace Nancy.Swagger.Annotations.Tests.Testdata.JsonNetEnricher
+{
+    [JsonObject(Description = "Description of a model")]
+    public class JsonNetEnricherModel
+    {
+        [JsonProperty("named")]
+        public string Named { get; set; }
+
+        [JsonProperty(Required = Required.AllowNull)]
+        public string RequiredAllowNull { get; set; }
+
+        [JsonProperty(Required = Required.Default)]
+        public string RequiredDefault { get; set; }
+
+        [JsonProperty(Required = Required.Always)]
+        public string RequiredAlways { get; set; }
+    }
+}

--- a/test/Nancy.Swagger.Annotations.Tests/Testdata/JsonNetEnricher/JsonNetEnricherRoutesModule.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/Testdata/JsonNetEnricher/JsonNetEnricherRoutesModule.cs
@@ -1,0 +1,24 @@
+﻿using Nancy.ModelBinding;
+using Nancy.Swagger.Annotations.Attributes;
+using Swagger.ObjectModel.ApiDeclaration;
+using System;
+
+namespace Nancy.Swagger.Annotations.Tests.Testdata.JsonNetEnricher
+{
+    public class JsonNetEnricherRoutesModule : NancyModule
+    {
+        public JsonNetEnricherRoutesModule()
+            : base("json-net-enricher-routes")
+        {
+            // Primitive response
+            Get["/models"] = _ => GetModels();            
+        }
+
+        [SwaggerRoute(HttpMethod.Get, "/models")]
+        [SwaggerRoute(Response = typeof(JsonNetEnricherModel[]))]
+        private static dynamic GetModels()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Nancy.Swagger.Annotations.Tests/Testdata/TestModel.InOtherNamespace.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/Testdata/TestModel.InOtherNamespace.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Nancy.Swagger.Annotations.Tests.InOtherNamespace
+namespace Nancy.Swagger.Annotations.Tests.Testdata.InOtherNamespace
 {
     public class TestModel
     {

--- a/test/Nancy.Swagger.Annotations.Tests/Testdata/TestModel.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/Testdata/TestModel.cs
@@ -1,7 +1,7 @@
 ﻿using Nancy.Swagger.Annotations.Attributes;
 using System.Collections.Generic;
 
-namespace Nancy.Swagger.Annotations.Tests
+namespace Nancy.Swagger.Annotations.Tests.Testdata
 {
     [SwaggerModel("Description of a model")]
     public class TestModel

--- a/test/Nancy.Swagger.Annotations.Tests/Testdata/TestRoutesModule.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/Testdata/TestRoutesModule.cs
@@ -3,7 +3,7 @@ using Nancy.Swagger.Annotations.Attributes;
 using Swagger.ObjectModel.ApiDeclaration;
 using System;
 
-namespace Nancy.Swagger.Annotations.Tests
+namespace Nancy.Swagger.Annotations.Tests.Testdata
 {
     public class TestRoutesModule : NancyModule
     {

--- a/test/Nancy.Swagger.Annotations.Tests/packages.config
+++ b/test/Nancy.Swagger.Annotations.Tests/packages.config
@@ -4,5 +4,6 @@
   <package id="ApprovalUtilities" version="3.0.7" targetFramework="net40" />
   <package id="Nancy" version="0.23.0" targetFramework="net40" />
   <package id="Nancy.Testing" version="0.23.0" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
I pushed PR #47 a while ago, but wasn't sure about the solution. After thinking about it again, I came to the conclusion it wasn't a very nice solution.

This PR introduces the concept of enriching the swagger data. You could implement a class which implements <code>ISwaggerDataEnricher</code>. This interface exposes four methods, which are called by the <code>SwaggerAnnotationsConverter</code> just after an instance containing data was created.

I implemented the <code>JsonNetEnricher</code> as an example, which uses reflection to find <code>JsonObjectAttribute</code> and <code>JsonPropertyAttribute</code> by name (so no dependency to Newtonsoft.Json is needed). It uses the data from these properties to enrich the <code>SwaggerModelData</code> and <code>SwaggerModelPropertyData</code>.

An approval test was added which demonstrates the resulting output.

I added this post-processing only in the Nancy.Swagger.Annotation project, because I'm not sure if this approach is suitable/needed when working with the <code>DefaultSwaggerMetadataConverter</code>.